### PR TITLE
Add publish step

### DIFF
--- a/src/commands/npm.yml
+++ b/src/commands/npm.yml
@@ -13,7 +13,7 @@ parameters:
   npm_command:
     description: the cdk command to run
     type: enum
-    enum: ["install", "run"]
+    enum: ["install", "run", "publish"]
   npm_params:
     description: the parameters to pass your cdk command
     type: string

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -14,8 +14,16 @@ parameters:
     default: ""
 
 steps:
+  - run:
+      name: Authenticate with registry
+      command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
   - npm:
       npm_command: publish
       npm_params: << parameters.npm_params >>
       npm_directory: << parameters.cdk_directory >>
-      persist: true
+  - run:
+      name: npm whoami
+      command: npm whoami
+  - run:
+      name: Clean up credentials.
+      command: rm -f $HOME/.npmrc

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -1,0 +1,21 @@
+description: >
+  npm publish
+
+executor: default
+
+parameters:
+  cdk_directory:
+    description: the directory where your cdk app resides
+    type: string
+    default: "."
+  npm_params:
+    description: the parameters to pass the `npm publish` command
+    type: string
+    default: ""
+
+steps:
+  - npm:
+      npm_command: publish
+      npm_params: << parameters.npm_params >>
+      npm_directory: << parameters.cdk_directory >>
+      persist: true


### PR DESCRIPTION
Add npm publish step to cdk orb to support moving watchful over.

Looks like it currently is failing with `You need to authorize this machine using npm adduser`. 