### PR TITLE
Add attach_at to all jobs to allow for custom workplace

### DIFF
--- a/src/commands/cdk.yml
+++ b/src/commands/cdk.yml
@@ -41,10 +41,6 @@ parameters:
     default: ENVIRONMENT
     description: The environment to apply on.
     type: env_var_name
-  env_var_steps:
-    description: Steps to configure environment variables
-    default: []
-    type: steps
   notify:
     default: false
     description: whether to notify slack
@@ -74,7 +70,6 @@ steps:
   - run:
       name: yarn list
       command: yarn list
-  - steps: <<parameters.env_var_steps>>
   - run:
       name: Run Cdk Command
       no_output_timeout: 60m

--- a/src/commands/cdk.yml
+++ b/src/commands/cdk.yml
@@ -70,9 +70,11 @@ steps:
   - run:
       name: yarn list
       command: yarn list
+      working_directory: << parameters.attach_at >>
   - run:
       name: Run Cdk Command
       no_output_timeout: 60m
+      working_directory: << parameters.attach_at >>
       command: |
         assume_creds=$(aws sts assume-role --role-session-name ${CIRCLE_WORKFLOW_ID} --role-arn arn:aws:iam::$AWS_ACCOUNT_ID:role/$ASSUME_AWS_PROFILE)
         export AWS_ACCESS_KEY_ID=$(echo $assume_creds | jq -r .Credentials.AccessKeyId)

--- a/src/commands/yarn.yml
+++ b/src/commands/yarn.yml
@@ -33,8 +33,7 @@ steps:
   - run:
       name: yarn list
       working_directory: << parameters.attach_at >>
-      command: |
-        yarn list
+      command: yarn list
   - run:
       name: yarn
       working_directory: << parameters.attach_at >>

--- a/src/commands/yarn.yml
+++ b/src/commands/yarn.yml
@@ -33,7 +33,10 @@ steps:
   - run:
       name: yarn list
       working_directory: << parameters.attach_at >>
-      command: yarn list
+      command: |
+        pwd
+        ls
+        yarn list
   - run:
       name: yarn
       working_directory: << parameters.attach_at >>

--- a/src/commands/yarn.yml
+++ b/src/commands/yarn.yml
@@ -32,12 +32,12 @@ steps:
       command: yarn --version
   - run:
       name: yarn list
+      working_directory: << parameters.attach_at >>
       command: |
-        pwd
-        ls
         yarn list
   - run:
       name: yarn
+      working_directory: << parameters.attach_at >>
       no_output_timeout: 30m
       command: |
         cd << parameters.yarn_directory >>

--- a/src/commands/yarn.yml
+++ b/src/commands/yarn.yml
@@ -32,7 +32,10 @@ steps:
       command: yarn --version
   - run:
       name: yarn list
-      command: yarn list
+      command: |
+        pwd
+        ls
+        yarn list
   - run:
       name: yarn
       no_output_timeout: 30m

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -4,6 +4,10 @@ description: >
 executor: default
 
 parameters:
+  attach_at:
+    description: where should we attach the workspace
+    default: "."
+    type: string
   cdk_directory:
     description: the directory where your cdk app resides
     type: string
@@ -19,4 +23,5 @@ steps:
       yarn_command: run
       yarn_params: build << parameters.yarn_params >>
       yarn_directory: << parameters.cdk_directory >>
+      attach_at: << parameters.attach_at >>
       persist: true

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -39,10 +39,6 @@ parameters:
     default: ENVIRONMENT
     description: The environment to apply on.
     type: env_var_name
-  env_var_steps:
-    description: Steps to configure environment variables
-    default: []
-    type: steps
   notify:
     default: false
     description: whether to notify slack
@@ -79,7 +75,6 @@ steps:
       aws_account_id: << parameters.aws_account_id >>
       aws_secret_access_key: << parameters.aws_secret_access_key >>
       environment: << parameters.environment >>
-      env_var_steps: << parameters.env_var_steps >>
       notify: << parameters.notify >>
       install_go: << parameters.install_go >>
       go_version: << parameters.go_version >>

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -4,6 +4,10 @@ description: >
 executor: default
 
 parameters:
+  attach_at:
+    description: where should we attach the workspace
+    default: "."
+    type: string
   cdk_directory:
     description: the directory where your cdk app resides
     type: string
@@ -62,6 +66,7 @@ steps:
   - esbuild
   - fix-git
   - cdk:
+      attach_at: << parameters.attach_at >>
       cdk_command: deploy
       cdk_directory: << parameters.cdk_directory >>
       cdk_params: << parameters.cdk_params >>

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -4,6 +4,10 @@ description: >
 executor: default
 
 parameters:
+  attach_at:
+    description: where should we attach the workspace
+    default: "."
+    type: string
   cdk_directory:
     description: the directory where your cdk app resides
     type: string
@@ -42,6 +46,7 @@ parameters:
 
 steps:
   - cdk:
+      attach_at: << parameters.attach_at >>
       cdk_command: destroy
       cdk_directory: << parameters.cdk_directory >>
       cdk_params: << parameters.cdk_params >>

--- a/src/jobs/diff.yml
+++ b/src/jobs/diff.yml
@@ -4,6 +4,10 @@ description: >
 executor: default
 
 parameters:
+  attach_at:
+    description: where should we attach the workspace
+    default: "."
+    type: string
   cdk_directory:
     description: the directory where your cdk app resides
     type: string
@@ -52,6 +56,7 @@ steps:
   - esbuild
   - fix-git
   - cdk:
+      attach_at: << parameters.attach_at >>
       cdk_command: diff
       cdk_directory: << parameters.cdk_directory >>
       cdk_params: << parameters.cdk_params >>

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -34,7 +34,7 @@ steps:
       command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
   - node/install-packages:
       pkg-manager: yarn
-      app-dir: "<< parameters.attach_at >> / << parameters.cdk_directory >>"
+      app-dir: "<< parameters.attach_at >>/<< parameters.cdk_directory >>"
   - run:
       name: yarn whoami
       command: yarn --whoami

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -19,11 +19,9 @@ parameters:
     type: env_var_name
 
 steps:
-  - attach_workspace:
-      at: << parameters.attach_at >>
-
   - checkout
-  
+  # - attach_workspace:
+  #     at: << parameters.attach_at >>
   # Yarn is already installed
   # - node/install-yarn
   - run:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -19,10 +19,7 @@ parameters:
     type: env_var_name
 
 steps:
-  - attach_workspace:
-      at: << parameters.attach_at >>
-  - checkout:
-      path: << parameters.attach_at >>
+  - checkout
   # Yarn is already installed
   # - node/install-yarn
   - run:
@@ -41,6 +38,19 @@ steps:
   - run:
       name: Clean up credentials.
       command: rm -f $HOME/.npmrc
+  - when:
+      condition:
+        not:
+          equal: 
+            - '.'
+            - << parameters.attach_at >>
+      steps:
+        - attach_workspace: 
+            at: << parameters.attach_at >>
+        - run:
+            name: Copy CWD to Workspace
+            command: |
+              cp -nr * << parameters.attach_at >>
   - persist_to_workspace:
       root: << parameters.attach_at >>
       paths:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -19,6 +19,8 @@ parameters:
     type: env_var_name
 
 steps:
+  - attach_workspace:
+      at: << parameters.attach_at >>
   - checkout
   # Yarn is already installed
   # - node/install-yarn

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -31,7 +31,7 @@ steps:
       command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
   - node/install-packages:
       pkg-manager: yarn
-      app-dir: "<< parameters.attach_at >>/<< parameters.cdk_directory >>"
+      app-dir: << parameters.cdk_directory >>
   - run:
       name: yarn whoami
       command: yarn --whoami
@@ -41,16 +41,13 @@ steps:
   - when:
       condition:
         not:
-          equal:
-            - '.'
-            - << parameters.attach_at >>
+          equal: ['.', << parameters.attach_at >>]
       steps:
         - attach_workspace:
             at: << parameters.attach_at >>
         - run:
             name: Copy CWD to Workspace
-            command: |
-              cp -nr * << parameters.attach_at >>
+            command: cp -nr * << parameters.attach_at >>
   - persist_to_workspace:
       root: << parameters.attach_at >>
       paths:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -19,8 +19,6 @@ parameters:
     type: env_var_name
 
 steps:
-  - attach_workspace:
-      at: << parameters.attach_at >>
   - checkout
   # Yarn is already installed
   # - node/install-yarn

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -41,11 +41,11 @@ steps:
   - when:
       condition:
         not:
-          equal: 
+          equal:
             - '.'
             - << parameters.attach_at >>
       steps:
-        - attach_workspace: 
+        - attach_workspace:
             at: << parameters.attach_at >>
         - run:
             name: Copy CWD to Workspace

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -20,8 +20,6 @@ parameters:
 
 steps:
   - checkout
-  # - attach_workspace:
-  #     at: << parameters.attach_at >>
   # Yarn is already installed
   # - node/install-yarn
   - run:
@@ -33,7 +31,7 @@ steps:
       command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
   - node/install-packages:
       pkg-manager: yarn
-      app-dir: << paramteres.attach_at >>/<< parameters.cdk_directory >>
+      app-dir: << parameters.cdk_directory >>
   - run:
       name: yarn whoami
       command: yarn --whoami

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -25,6 +25,9 @@ steps:
   # Yarn is already installed
   # - node/install-yarn
   - run:
+      name: is alpha working?
+      command: echo yes
+  - run:
       name: yarn version
       command: yarn --version
   - esbuild

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -19,9 +19,10 @@ parameters:
     type: env_var_name
 
 steps:
-  - checkout
   - attach_workspace:
       at: << parameters.attach_at >>
+  - checkout:
+      path: << parameters.attach_at >>
   # Yarn is already installed
   # - node/install-yarn
   - run:
@@ -33,7 +34,7 @@ steps:
       command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
   - node/install-packages:
       pkg-manager: yarn
-      app-dir: << parameters.cdk_directory >>
+      app-dir: "<< parameters.attach_at >> / << parameters.cdk_directory >>"
   - run:
       name: yarn whoami
       command: yarn --whoami

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -20,6 +20,8 @@ parameters:
 
 steps:
   - checkout
+  - attach_workspace:
+      at: << parameters.attach_at >>
   # Yarn is already installed
   # - node/install-yarn
   - run:
@@ -31,7 +33,7 @@ steps:
       command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
   - node/install-packages:
       pkg-manager: yarn
-      app-dir: << parameters.cdk_directory >>
+      app-dir: << paramteres.attach_at >>/<< parameters.cdk_directory >>
   - run:
       name: yarn whoami
       command: yarn --whoami

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -20,6 +20,8 @@ parameters:
 
 steps:
   - checkout
+  - attach_workspace:
+      at: << parameters.attach_at >>
   # Yarn is already installed
   # - node/install-yarn
   - run:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -19,14 +19,13 @@ parameters:
     type: env_var_name
 
 steps:
-  - checkout
   - attach_workspace:
       at: << parameters.attach_at >>
+
+  - checkout
+  
   # Yarn is already installed
   # - node/install-yarn
-  - run:
-      name: is alpha working?
-      command: echo yes
   - run:
       name: yarn version
       command: yarn --version

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -4,6 +4,10 @@ description: >
 executor: default
 
 parameters:
+  attach_at:
+    description: where should we attach the workspace
+    default: "."
+    type: string
   cdk_directory:
     description: the directory where your cdk app resides
     type: string
@@ -15,6 +19,7 @@ parameters:
 
 steps:
   - yarn:
+      attach_at: << parameters.yarn_params >>
       yarn_command: run
       yarn_params: lint << parameters.yarn_params >>
       yarn_directory: << parameters.cdk_directory >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -4,6 +4,10 @@ description: >
 executor: default
 
 parameters:
+  attach_at:
+    description: where should we attach the workspace
+    default: "."
+    type: string
   cdk_directory:
     description: the directory where your cdk app resides
     type: string
@@ -29,6 +33,7 @@ steps:
             version: <<parameters.go_version>>
   - fix-git
   - yarn:
+      attach_at: << parameters.attach_at >>
       yarn_command: run
       yarn_params: test << parameters.yarn_params >>
       yarn_directory: << parameters.cdk_directory >>


### PR DESCRIPTION
Hi DevOps, 
Adding `attach_at` parameter to all `jobs` in `cdk-orb`. By allowing user override, cdk steps have access to other .circleci artifacts. With the PR, one could add artifacts like so.

Reason: Certain environment variables, such as the github repo tag, are helpful/necessary for CDK deployment. This PR offers the opportunity to pass an env var file to typescript via a circleci workspace.

The current workaround to the above issue is to create a `custom-cdk` job that runs `attach_workspace` before running all `cdk` command: [example](https://github.com/myhelix/helix-sars-klados/blob/main/.circleci/config.yml#L409-L428)

The PR code changes in a nutshell:  the `attach_at` parameter is used as the working directory for all cdk / yarn / npm commands. `cdk/install` installs all cdk dependancies into the `attach_at` parameter so all other jobs must be called from this directory.

Sample use case:
```yaml
# .circleci/config.yml

jobs:
  build-and-push:
    executor: default
    steps:
      - attach_workspace:
          at: /tmp/workspace
      - run:
          name: Create Docker Variables and Persist to Workspace
          command: |
            "export GIT_TAG=MY_GIT_TAG" >> /tmp/workspace/bashvars
      - persist_to_workspace:
          root: /tmp/workspace
          paths:
            - bashvars

workflows:
  main:
    jobs:
      - build-and-push:
          context: basic
      - cdk/install:
          cdk_directory: cdk
          attach_at: /tmp/workspace
          context: npm-readonly # with npmjs credentials
          requires:
            - build-and-push
            - approve-deploy-dev
      - cdk/build:
          cdk_directory: cdk
          attach_at: /tmp/workspace
          requires:
            - cdk/install
      - cdk/diff:
          cdk_directory: cdk
          attach_at: /tmp/workspace
          context: master-development
          requires:
            - cdk/build
      - cdk/destroy:
          cdk_directory: cdk
          attach_at: /tmp/workspace
          cdk_stack: yourStackName
          context: master-development
          requires:
            - cdk/diff
      - cdk/deploy:
          cdk_directory: cdk
          attach_at: /tmp/workspace
          context: master-development
          requires:
            - cdk/destroy
```
Then the artifact (in this case a environment variable file) could be accessed in cdk like so
```typescript
// cdk/lib/cdk.ts

import * as dotenv from 'dotenv';

dotenv.config({path: './bashvars'})

var gitTag: string = process.env.GIT_TAG as string
```