### PR TITLE
[semver:patch] Add Node Version Parameter to all Jobs

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ docker:
   - image: 'cimg/node:<<parameters.tag>>'
 parameters:
   tag:
-    default: lts
+    default: 18.13.0
     description: >
       Pick a specific circleci/node image variant:
       https://hub.docker.com/r/cimg/node/tags

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -1,7 +1,9 @@
 description: >
   yarn run build
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.node_version >>
 
 parameters:
   attach_at:
@@ -16,6 +18,10 @@ parameters:
     description: the parameters to pass the `yarn run build` command
     type: string
     default: ""
+  node_version:
+    description: the version of node to use in executor
+    type: string
+    default: "18.13.0"
 
 steps:
   - esbuild

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -3,7 +3,7 @@ description: >
 
 executor:
   name: default
-  tag: 18.13.0
+  tag: << parameters.node_version >>
 
 parameters:
   attach_at:
@@ -57,6 +57,10 @@ parameters:
     description: the version of go to install
     type: string
     default: "1.15.10"
+  node_version:
+    description: the version of node to use in executor
+    type: string
+    default: "18.13.0"
 
 steps:
   - when:

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -1,7 +1,9 @@
 description: >
   cdk deploy
 
-executor: default
+executor:
+  name: default
+  tag: 18.13.0
 
 parameters:
   attach_at:

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -1,7 +1,9 @@
 description: >
   cdk destroy
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.node_version >>
 
 parameters:
   attach_at:
@@ -43,6 +45,10 @@ parameters:
     default: false
     description: whether to notify slack
     type: boolean
+  node_version:
+    description: the version of node to use in executor
+    type: string
+    default: "18.13.0"
 
 steps:
   - cdk:

--- a/src/jobs/diff.yml
+++ b/src/jobs/diff.yml
@@ -1,7 +1,9 @@
 description: >
   cdk diff
 
-executor: default
+executor:
+  default:
+    tag: 18.13.0
 
 parameters:
   attach_at:

--- a/src/jobs/diff.yml
+++ b/src/jobs/diff.yml
@@ -3,7 +3,7 @@ description: >
 
 executor:
   name: default
-  tag: 18.13.0
+  tag: << parameters.node_version >>
 
 parameters:
   attach_at:
@@ -53,6 +53,10 @@ parameters:
     description: the version of go to install
     type: string
     default: "1.15.10"
+  node_version:
+    description: the version of node to use in executor
+    type: string
+    default: "18.13.0"
 
 steps:
   - esbuild

--- a/src/jobs/diff.yml
+++ b/src/jobs/diff.yml
@@ -2,8 +2,8 @@ description: >
   cdk diff
 
 executor:
-  default:
-    tag: 18.13.0
+  name: default
+  tag: 18.13.0
 
 parameters:
   attach_at:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -1,7 +1,9 @@
 description: >
   yarn install
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.node_version >>
 
 parameters:
   attach_at:
@@ -17,6 +19,10 @@ parameters:
     description: |
       The token used to auth with npmjs
     type: env_var_name
+  node_version:
+    description: the version of node to use in executor
+    type: string
+    default: "18.13.0"
 
 steps:
   - checkout

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -1,7 +1,9 @@
 description: >
   yarn run test
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.node_version >>
 
 parameters:
   attach_at:
@@ -24,6 +26,10 @@ parameters:
     description: the version of go to install
     type: string
     default: "1.15.10"
+  node_version:
+    description: the version of node to use in executor
+    type: string
+    default: "18.13.0"
 
 steps:
   - when:


### PR DESCRIPTION
- Add node version parameter to all jobs to allow for custom node versions.
- Update default node version to 18.13.0