### PR TITLE
[semver:patch] pin yarn version to 1.22.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ orb.yml
 
 node_modules
 yarn.lock
+.idea/*

--- a/src/commands/cdk.yml
+++ b/src/commands/cdk.yml
@@ -63,7 +63,8 @@ steps:
         - go/install:
             version: <<parameters.go_version>>
   - assume_oidc_role
-  - node/install-yarn
+  - node/install-yarn:
+      version: 1.22.19
   - run:
       name: yarn version
       command: yarn --version

--- a/src/commands/yarn.yml
+++ b/src/commands/yarn.yml
@@ -26,7 +26,8 @@ parameters:
 steps:
   - attach_workspace:
       at: << parameters.attach_at >>
-  - node/install-yarn
+  - node/install-yarn:
+      version: 1.22.19
   - run:
       name: yarn version
       command: yarn --version


### PR DESCRIPTION
This tries to fix the [issue](https://github.com/yarnpkg/yarn/issues/9011) that was introduced with the release of yarn 1.22.20, that made pipelines fail on the build steps.

This should be a workaround, as we expect that a new version of yarn fixes this

PD: Thanks @RussMilneHelix for pinpointing the issue to the yarn version 🙌 