### PR TITLE
[semver:minor] enable rollbar notifications in all the env without no…

### DIFF
--- a/src/commands/cdk.yml
+++ b/src/commands/cdk.yml
@@ -83,10 +83,11 @@ steps:
         export AWS_SESSION_TOKEN=$(echo $assume_creds | jq -r .Credentials.SessionToken)
         cd << parameters.cdk_directory >>
         npx cdk << parameters.cdk_command >> << parameters.cdk_stack >> << parameters.cdk_params >>
+  - rollbar #notify
   - when:
       condition: <<parameters.notify>>
       steps:
         - slack/notify:
             color: '#22e33f'
             message: 'Deployed to << parameters.environment >>.'
-        - rollbar #notify
+


### PR DESCRIPTION
All environments notifies should go to Rollbar
Only production notifies goes to slack channel since it has dependency of notify:true flag
Engineers doesn’t need to make any changes on their repos: Nope, if the above are the requirements.