### PR TITLE
[semver:minor] - use Node 20 for newer npm

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ docker:
   - image: 'cimg/node:<<parameters.tag>>'
 parameters:
   tag:
-    default: 18.13.0
+    default: 20.18.3
     description: >
       Pick a specific circleci/node image variant:
       https://hub.docker.com/r/cimg/node/tags


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/myhelix/enrollment/965/workflows/d9457059-e5f2-4b6f-b28e-1c5b3ca53418/jobs/9739/parallel-runs/0/steps/0-110

AWS CDK introduced a version 2.1000.0 for CDK CLI as part of https://aws.amazon.com/blogs/opensource/aws-cdk-is-splitting-construct-library-and-cli/

This semver confuses npm that's included in Node 18.13

I can confirm npm included in Node 20 is able to generate the correct URL and download this type of semver